### PR TITLE
Avoid allocations in solving linear equations

### DIFF
--- a/perf/mgcep.jl
+++ b/perf/mgcep.jl
@@ -76,6 +76,13 @@ function perf_mgcep()
     println("$r x slower than SPTK implementation")
 end
 
+gc_disable()
+
+gc()
 perf_mcep()
+
+gc()
 perf_mgcep()
+
+gc()
 perf_mc2b()

--- a/perf/mgcep.jl
+++ b/perf/mgcep.jl
@@ -2,6 +2,8 @@ using MelGeneralizedCepstrums: _mcep, _mgcep, mc2b
 import SPTK
 
 function perf_mc2b()
+    println("benchmark: mc2b")
+
     srand(98765)
     mc = rand(21)
     α = 0.41

--- a/src/mcep.jl
+++ b/src/mcep.jl
@@ -132,8 +132,8 @@ function periodogram2mcep{T<:FloatingPoint}(periodogram::AbstractVector{T}, # mo
         fill_hankel!(Hm, he)
         fill_toeplitz!(Tm, te)
 
-        for j=1:order+1, i=1:order+1
-            @inbounds Tm_plus_Hm[i,j] = Hm[i,j] + Tm[i,j]
+        for i=1:length(Hm)
+            @inbounds Tm_plus_Hm[i] = Hm[i] + Tm[i]
         end
 
         # Solve Ax = b

--- a/src/mcep.jl
+++ b/src/mcep.jl
@@ -136,8 +136,14 @@ function periodogram2mcep{T<:FloatingPoint}(periodogram::AbstractVector{T}, # mo
             @inbounds Tm_plus_Hm[i,j] = Hm[i,j] + Tm[i,j]
         end
 
-        # solve linear equation and add the solution vector to mel-cepstrum
-        mc += Tm_plus_Hm \ b
+        # Solve Ax = b
+        # NOTE: both Tm_plus_Hm and b are overwritten
+        A_ldiv_B!(lufact!(Tm_plus_Hm), b)
+
+        # Add the solution vector to mel-cepstrum
+        for i=1:length(b)
+            @inbounds mc[i] += b[i]
+        end
     end
 
     mc

--- a/src/mgcep.jl
+++ b/src/mgcep.jl
@@ -190,8 +190,8 @@ function newton!{T}(c::AbstractVector{T}, # mel-generalized cepstrum stored
     he = sub(qr, 3:2order+1)
     fill_hankel!(Hm, he)
 
-    for j=1:order, i=1:order
-        @inbounds Tm_plus_Hm[i,j] = Hm[i,j] + Tm[i,j]
+    for i=1:length(Hm)
+        @inbounds Tm_plus_Hm[i] = Hm[i] + Tm[i]
     end
 
     # Solve Ax = b

--- a/src/mgcep.jl
+++ b/src/mgcep.jl
@@ -95,7 +95,9 @@ function newton!{T}(c::AbstractVector{T}, # mel-generalized cepstrum stored
                     qr::Vector{T} = zeros(T, length(x)),
                     qi::Vector{T} = zeros(T, length(x)),
                     Tm::Matrix{T} = Array(T, order, order),
-                    Hm::Matrix{T} = Array(T, order, order)
+                    Hm::Matrix{T} = Array(T, order, order),
+                    Tm_plus_Hm::Matrix{T} = Array(T, order, order),
+                    b::Vector{T} = Array(T, order), # right side of equation Ax = b
     )
     @assert length(x) > length(c)
     @assert n < length(x)
@@ -188,9 +190,16 @@ function newton!{T}(c::AbstractVector{T}, # mel-generalized cepstrum stored
     he = sub(qr, 3:2order+1)
     fill_hankel!(Hm, he)
 
-    # solve linear equation
-    b = (Tm + Hm) \ sub(rr, 2:order+1)
+    for j=1:order, i=1:order
+        @inbounds Tm_plus_Hm[i,j] = Hm[i,j] + Tm[i,j]
+    end
 
+    # Solve Ax = b
+    # NOTE: both Tm_plus_Hm and b are overwritten
+    copy!(b, 1, rr, 2, order)
+    A_ldiv_B!(lufact!(Tm_plus_Hm), b)
+
+    # Add the solution vector
     for i=2:order+1
         @inbounds c[i] += b[i-1]
     end
@@ -276,6 +285,8 @@ function _mgcep{T<:FloatingPoint}(x::AbstractVector{T},          # a *windowed* 
     qi = zeros(T, length(x))
     Tm = Array(T, order, order)
     Hm = Array(T, order, order)
+    Tm_plus_Hm = Array(T, order, order)
+    b = Array(T, order)
 
     # FFT workspace
     y = Array(Complex{T}, length(x))
@@ -284,7 +295,7 @@ function _mgcep{T<:FloatingPoint}(x::AbstractVector{T},          # a *windowed* 
 
     bᵧ′ = zeros(T, order+1)
     ϵ⁰ = newton!(bᵧ′, periodogram, order, α, -one(T), n, 1, y, z, bplan,
-                 cr, pr, rr, ri, qr, qi, Tm, Hm)
+                 cr, pr, rr, ri, qr, qi, Tm, Hm, Tm_plus_Hm, b)
 
     if γ != -one(T)
         d = Array(T, order+1)
@@ -309,7 +320,7 @@ function _mgcep{T<:FloatingPoint}(x::AbstractVector{T},          # a *windowed* 
         ϵᵗ = ϵ⁰
         for i=1:maxiter
             ϵ = newton!(bᵧ′, periodogram, order, α, γ, n, i, y, z, bplan,
-                        cr, pr, rr, ri, qr, qi, Tm, Hm)
+                        cr, pr, rr, ri, qr, qi, Tm, Hm, Tm_plus_Hm, b)
             if i >= miniter
                 err = abs((ϵᵗ - ϵ)/ϵ)
                 verbose && println("nmse: $err")


### PR DESCRIPTION
also disabled gc in benchmarks.
### benchmarks on v0.4.0-dev

before:

```
benchmark: mcep
elapsed time: 10.185991948 seconds (355 MB allocated)
elapsed time: 7.223171397 seconds (656 kB allocated)
1.410182851334218 x slower than SPTK implementation
benchmark: mgcep
elapsed time: 9.287685327 seconds (89 MB allocated)
elapsed time: 6.560359736 seconds (65 kB allocated)
1.4157281407784421 x slower than SPTK implementation
```

after:

```
benchmark: mcep
elapsed time: 7.955997896 seconds (230 MB allocated)
elapsed time: 7.11089448 seconds (656 kB allocated)
1.1188462983899323 x slower than SPTK implementation
benchmark: mgcep
elapsed time: 8.378429405 seconds (79 MB allocated)
elapsed time: 6.650064232 seconds (65 kB allocated)
1.2599020629675701 x slower than SPTK implementation
```
