### PR TITLE
New design: separate definition and state for spectral envelope parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - release
+#  - release
   - nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ function mgcep{T<:FloatingPoint,N}(x::AbstractArray{T,N},
 end
 ```
 
-where `x` is a input windowed signal, `order` is the order of cepstrum (expect for 0-th), `α` is a frequency warping parameter and `γ` is a paramter of generalized log function. It returns a value typed `MelGeneralizedCepstrum{F,L,T,N}` which `F` and `L` are estimated by the value of `α` and `γ`. When `γ = 0`, mel-generalized cepstrum analysis corresponds to mel-cepstrum analysis. For more information about mel-generalized cepstrum, please see [the paper](http://www.sp.nitech.ac.jp/~tokuda/selected_pub/pdf/conference/tokuda_icslp1994.pdf).
+where `x` is a input windowed signal, `order` is the order of cepstrum (expect for 0-th), `α` is a frequency warping parameter and `γ` is a parameter of generalized log function. It returns a value typed `MelGeneralizedCepstrum{F,L,T,N}` which `F` and `L` are estimated by the value of `α` and `γ`. When `γ = 0`, mel-generalized cepstrum analysis corresponds to mel-cepstrum analysis. For more information about mel-generalized cepstrum, please see [the paper](http://www.sp.nitech.ac.jp/~tokuda/selected_pub/pdf/conference/tokuda_icslp1994.pdf).
 
 ## How spectrum envelope estimation works
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,35 @@
 environment:
   matrix:
-  - JULIAVERSION: "win32"
-  - JULIAVERSION: "win64"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
 
 install:
 # Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/download/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 
 build_script:
-  # Need to convert from shallow to complete for Pkg.clone to work
+# Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.init(); Pkg.clone(pwd(), \"MelGeneralizedCepstrums\")"
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"MelGeneralizedCepstrums\"); Pkg.build(\"MelGeneralizedCepstrums\");
+      Pkg.clone(\"https://github.com/r9y9/SPTK.jl\"); Pkg.build(\"SPTK\")"
+
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"MelGeneralizedCepstrums\")"
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"MelGeneralizedCepstrums\")"

--- a/perf/mgcep.jl
+++ b/perf/mgcep.jl
@@ -87,7 +87,7 @@ function perf_mgcep()
     println("$r x slower than SPTK implementation")
 end
 
-gc_disable()
+gc_enable(false)
 
 gc()
 perf_mcep()

--- a/src/MelGeneralizedCepstrums.jl
+++ b/src/MelGeneralizedCepstrums.jl
@@ -1,35 +1,42 @@
 module MelGeneralizedCepstrums
 
 export
-    # Types
+    # Spectral parameter types
+    SpectralParam,
     MelGeneralizedCepstrum,
-    MelFrequencyCepstrum,
-    LinearFrequencyCepstrum,
-    GeneralizedLogCepstrum,
-    StandardLogCepstrum,
-    AllPoleCepstrum,
-    LinearCepstrum,
-    MelCepstrum,
     GeneralizedCepstrum,
+    MelCepstrum,
+    LinearCepstrum,
+    AllPoleCepstrum,
     MelAllPoleCepstrum,
-
-    MelLinearPredictionCoef,
+    LinearPredictionCoefVariants,
     LinearPredictionCoef,
+    LineSpectralPair,
+    PartialAutoCorrelation,
 
-    MelGeneralizedCepstrumFilterCoef,
-    LMADFCoef,
-    MLSADFCoef,
-    MGLSADFCoef,
+    # State, which keeps actual spectral parameter values
+    SpectralParamState,
 
-    # Basic property of Mel-generalized cepstrum
-    order,           # order of cepstrum (not including 0-th coef.)
-    allpass_alpha,   # all-pass constant (alpha)
-    glog_gamma,      # parameter of generalized log function
-    powercoef,       # power coef. (0-th order of mgcep)
+    # Generic interfaces
+    estimate,        # estimate spectral parameter values
+    params,          # returns parameters of a spectral parameter
+    param_order,     # returns order of a spectral parameter
 
-    # Feature extraction
-    mgcep,           # mel-generalized cepstrum analysis
+    # Mel-generalized cepstrum properties
+    allpass_alpha,   # all-pass constant (α)
+    glog_gamma,      # parameter of generalized log function (γ)
+
+    # Spectral state properties
+    paramdef,        # returns parameter definition from state
+    rawdata,         # returns rawdata in state
+    has_loggain,
+    gain_normalized,
+    ready_to_filt,
+
+    # Spectral parameter estimation
+    gcep,            # generalized cepstrum analysis
     mcep,            # mel-cepstrum analysis
+    mgcep,           # mel-generalized cepstrum analysis
     lpc,             # linear prediction (pipe to mgcep for now)
     periodogram2mcep,# periodogram to mel-cepstrum
 
@@ -37,36 +44,34 @@ export
 
     # Conversions
     lpc2c,           # LPC to cepstrum
-    lpc2c!,          #
+    lpc2lsp,         # LPC -> LSP
+    lpc2par,         # LPC -> PARCOR
     mc2b,            # mel-cepstrum -> mlsadf filter coef.
     mc2b!,           #
-    mc2e,            # mel-cesptrum to energy
+    mc2e,            # mel-cesptrum to energy (TODO: need more tests)
     mgc2b,           # mel-generalized cepstrum -> mglsadf coef.
     mgc2b!,          #
     mgc2sp,          # mel-generalized cepstrum -> spectrum envelope
     b2mc,            # mlsadf filter coef. -> mel-cepstrum
     b2mc!,           #
-    b2c,             # b2c in _mgcep.c
-    b2c!,            #
     gnorm,           # gain normalization for mel-generalized cepstrum
     gnorm!,          #
     ignorm,          # inverse gain normalization for mel-generalized cepstrum
     ignorm!,         #
     c2ir,            # cepstrum -> impulse response
     freqt,           # frequency transform
-    freqt!,          #
-    frqtr,           # frqtr in _mcep.c
-    frqtr!,          #
     gc2gc,           # generalized cepstrum -> genralized cepstrum
-    gc2gc!,          #
     mgc2mgc          # mel-generalized cepstrum -> mel-generalized cepstrum
 
 for fname in [
               "common",
-              "mgcep",
+              "gcep",
               "mcep",
+              "mgcep",
               "lpc",
               "lpc2c",
+              "lpc2lsp",
+              "lpc2par",
               "mcepalpha",
               "mc2b",
               "mc2e",

--- a/src/b2c.jl
+++ b/src/b2c.jl
@@ -1,6 +1,7 @@
-function b2c!{T<:FloatingPoint}(wc::AbstractVector{T}, c::AbstractVector{T},
-                                α::FloatingPoint;
-                                prev::Vector{T}=Array(T,length(wc)))
+function b2c!(wc::AbstractVector, c::AbstractVector, α,
+              prev=Array(eltype(wc),length(wc)))
+    T = eltype(wc)
+
     fill!(wc, zero(T))
     desired_order = length(wc) - 1
 
@@ -20,8 +21,4 @@ function b2c!{T<:FloatingPoint}(wc::AbstractVector{T}, c::AbstractVector{T},
     wc
 end
 
-function b2c{T<:FloatingPoint}(c::AbstractVector{T}, order::Int,
-                               α::FloatingPoint)
-    wc = Array(T, order+1)
-    b2c!(wc, c, α)
-end
+b2c(c::AbstractVector, order, α) = b2c!(Array(eltype(c), order+1), c, α)

--- a/src/b2mc.jl
+++ b/src/b2mc.jl
@@ -1,6 +1,6 @@
-function b2mc!{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint)
+function b2mc!(mc::AbstractVector, α)
     m = length(mc)
-    o = zero(T)
+    o = zero(eltype(mc))
 
     mc[m] = mc[m]
     d = mc[m]
@@ -13,14 +13,25 @@ function b2mc!{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint)
     mc
 end
 
-function b2mc{T<:FloatingPoint}(b::AbstractVector{T}, α::FloatingPoint)
-    mc = copy(b)
-    b2mc!(mc, α)
+b2mc(b::AbstractVector, α=0.35) = b2mc!(copy(b), α)
+
+function b2mc!{T<:MelCepstrum}(state::SpectralParamState{T})
+    assert_ready_to_filt(state)
+
+    def = paramdef(state)
+    α = allpass_alpha(def)
+    data = rawdata(state)
+    state.data = b2mc!(data, α)
+    state.ready_to_filt = false
+    state
 end
 
-function b2mc{F,L,T,N}(c::MelGeneralizedCepstrumFilterCoef{F,L,T,N})
-    α = allpass_alpha(c)
-    γ = glog_gamma(c)
-    raw = b2mc(rawdata(c), α)
-    MelGeneralizedCepstrum{F,L,T,N}(α, γ, raw)
+function b2mc!{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    throw(ArgumentError("""
+                        filter coefficients based on mel-generalized cesptrum cannot be converted to mel-cepstrum"""))
+
+end
+
+function b2mc{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    b2mc!(copy(state))
 end

--- a/src/c2ir.jl
+++ b/src/c2ir.jl
@@ -1,5 +1,5 @@
-function c2ir{T<:FloatingPoint}(c::AbstractVector{T}, len::Int)
-    h = Array(T, len)
+function c2ir(c::AbstractVector, len=256)
+    h = Array(eltype(c), len)
     m = length(c) - 1
 
     h[1] = exp(c[1])
@@ -14,5 +14,3 @@ function c2ir{T<:FloatingPoint}(c::AbstractVector{T}, len::Int)
 
     h
 end
-
-c2ir(c::MelGeneralizedCepstrum, len::Int) = c2ir(rawdata(c), len)

--- a/src/extend.jl
+++ b/src/extend.jl
@@ -1,56 +1,56 @@
 ## Extend functions for matrix input (col-wise) ##
 
-for f in [
-          :lpc2c!,
-          :mc2b!,
-          :mgc2b!,
-          :b2mc!,
-          :b2c!,
-          :gnorm!,
-          :ignorm!,
-          :freqt!,
-          :frqtr!,
-          :gc2gc!
-          ]
+const vec2vec_inplace = [
+                         :lpc2c!,
+                         :mc2b!,
+                         :mgc2b!,
+                         :b2mc!,
+                         :b2c!,
+                         :gnorm!,
+                         :ignorm!,
+                         :freqt!,
+                         :frqtr!,
+                         :gc2gc!,
+                         :mgc2mgc!
+                         ]
+
+for f in vec2vec_inplace
     @eval begin
-        function ($f){T<:FloatingPoint}(x::AbstractMatrix{T}, args...; kargs...)
+        function ($f)(x::AbstractMatrix, args...; kargs...)
             for i = 1:size(x, 2)
-                @inbounds x[:, i] = $f(x[:, i], args...; kargs...)
-            end
-            x
-        end
-        function ($f){T<:FloatingPoint}(x::Matrix{T}, args...; kargs...)
-            for i = 1:size(x, 2)
-                @inbounds $f(sub(x, 1:size(x, 1), i), args...; kargs...)
+                @inbounds $f(sub(x, :, i), args...; kargs...)
             end
             x
         end
     end
 end
 
-for f in [
-          :_mcep,
-          :_mgcep,
-          :lpc2c!,
-          :mc2b,
-          :mgc2b,
-          :mgc2sp,
-          :gnorm,
-          :ignorm,
-          :c2ir,
-          :freqt,
-          :gc2gc,
-          :mgc2mgc
-          ]
+const vec2vec = [
+                 :_mcep,
+                 :_mgcep,
+                 :lpc2c,
+                 :mc2b,
+                 :mgc2b,
+                 :b2mc,
+                 :b2c,
+                 :gnorm,
+                 :ignorm,
+                 :c2ir,
+                 :freqt,
+                 :gc2gc,
+                 :mgc2mgc
+                 ]
+
+for f in vec2vec
     @eval begin
-        function ($f){T<:FloatingPoint}(x::AbstractMatrix{T}, args...; kargs...)
+        function ($f)(x::AbstractMatrix, args...; kargs...)
             r = $f(x[:, 1], args...; kargs...)
             ret = Array(eltype(x), size(r, 1), size(x, 2))
             for i = 1:length(r)
                 @inbounds ret[i, 1] = r[i]
             end
             for i = 2:size(x, 2)
-                @inbounds ret[:, i] = $f(x[:, i], args...; kargs...)
+                @inbounds ret[:, i] = $f(sub(x, :, i), args...; kargs...)
             end
             ret
         end

--- a/src/freqt.jl
+++ b/src/freqt.jl
@@ -1,19 +1,18 @@
-function freqt!{T<:FloatingPoint}(wc::AbstractVector{T}, c::AbstractVector{T},
-                                  α::FloatingPoint;
-                                  prev::Vector{T}=Array(T,length(wc)))
-    fill!(wc, zero(T))
-    desired_order = length(wc) - 1
+function freqt!(wc::AbstractVector, c::AbstractVector, α;
+                prev=Array(eltype(wc), length(wc)))
+    fill!(wc, zero(eltype(wc)))
+    dst_order = length(wc) - 1
 
     m1 = length(c)-1
-    for i=-m1:0
+    for i in -m1:0
         copy!(prev, wc)
-        if desired_order >= 0
+        if dst_order >= 0
             @inbounds wc[1] = c[-i+1] + α*prev[1]
         end
-        if desired_order >= 1
+        if dst_order >= 1
             wc[2] = (1.0-α*α)*prev[1] + α*prev[2]
         end
-        for m=3:desired_order+1
+        for m=3:dst_order+1
             @inbounds wc[m] = prev[m-1] + α*(prev[m] - wc[m-1])
         end
     end
@@ -21,16 +20,22 @@ function freqt!{T<:FloatingPoint}(wc::AbstractVector{T}, c::AbstractVector{T},
     wc
 end
 
-function freqt{T<:FloatingPoint}(c::AbstractVector{T}, order::Int,
-                                 α::FloatingPoint)
-    wc = Array(T, order+1)
+function freqt(c::AbstractVector, order=25, α=0.35)
+    wc = Array(eltype(c), order+1)
     freqt!(wc, c, α)
 end
 
-function freqt(c::MelGeneralizedCepstrum, order::Int, α²::FloatingPoint)
-    raw = rawdata(c)
-    α¹ = allpass_alpha(c)
+function freqt{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T},
+                                          order=param_order(paramdef(state)),
+                                          α²=allpass_alpha(paramdef(state)))
+    assert_not_ready_to_filt(state)
+
+    def = paramdef(state)
+    α¹ = allpass_alpha(def)
     α = (α²-α¹) / (1.0-α²*α¹)
-    cc = freqt(raw, order, α)
-    MelGeneralizedCepstrum(α, glog_gamma(c), cc)
+    γ = glog_gamma(def)
+    data = rawdata(state)
+    newdef = MelGeneralizedCepstrum(order, α², γ)
+    SpectralParamState(newdef, freqt(data, order, α),
+                       has_loggain(state), gain_normalized(state))
 end

--- a/src/frqtr.jl
+++ b/src/frqtr.jl
@@ -1,17 +1,15 @@
-function frqtr!{T<:FloatingPoint}(wc::AbstractVector{T},
-                                  c::AbstractVector{T},
-                                  α::FloatingPoint;
-                                  prev::Vector{T}=Array(T,length(wc)))
-    fill!(wc, zero(T))
-    desired_order = length(wc) - 1
+function frqtr!(wc::AbstractVector, c::AbstractVector, α,
+                prev::Vector=Array(eltype(wc), length(wc)))
+    fill!(wc, zero(eltype(wc)))
+    dst_order = length(wc) - 1
 
     m1 = length(c)-1
-    for i=-m1:0
+    for i in -m1:0
         copy!(prev, wc)
-        if desired_order >= 0
+        if dst_order >= 0
             @inbounds wc[1] = c[-i+1]
         end
-        for m=2:desired_order+1
+        for m=2:dst_order+1
             @inbounds wc[m] = prev[m-1] + α*(prev[m] - wc[m-1])
         end
     end
@@ -19,14 +17,6 @@ function frqtr!{T<:FloatingPoint}(wc::AbstractVector{T},
     wc
 end
 
-function frqtr{T<:FloatingPoint}(c::AbstractVector{T}, order::Int,
-                                 α::FloatingPoint)
-    wc = Array(T, order+1)
-    frqtr!(wc, c, α)
-end
-
-function frqtr(c::MelGeneralizedCepstrum, order::Int, α::FloatingPoint)
-    raw = rawdata(c)
-    cc = frqtr(raw, order, α)
-    MelGeneralizedCepstrum(allpass_alpha(c)+α, glog_gamma(c), cc)
+function frqtr(c::AbstractVector, order=25, α=0.35)
+    frqtr!(Array(eltype(c), order+1), c, α)
 end

--- a/src/gc2gc.jl
+++ b/src/gc2gc.jl
@@ -1,42 +1,47 @@
-function gc2gc{T<:FloatingPoint}(c1::AbstractVector{T},
-                                 γ¹::FloatingPoint,
-                                 m2::Int,
-                                 γ²::FloatingPoint)
-    c2 = Array(T, m2+1)
-    gc2gc!(c2, c1, γ¹, γ²)
-end
+function gc2gc!(dst_ceps::AbstractVector, dst_γ,
+                src_ceps::AbstractVector, src_γ)
+    fill!(dst_ceps, zero(eltype(dst_ceps)))
+    dst_order = length(dst_ceps)-1
+    m1 = length(src_ceps)-1
+    dst_ceps[1] = src_ceps[1]
 
-function gc2gc!{T<:FloatingPoint}(c2::AbstractVector{T},
-                                  c1::AbstractVector{T},
-                                  γ¹::FloatingPoint,
-                                  γ²::FloatingPoint)
-    fill!(c2, zero(T))
-    m2 = length(c2)-1
-    m1 = length(c1)-1
-    c2[1] = c1[1]
-
-    for m=2:m2+1
+    for m=2:dst_order+1
         ss1, ss2 = 0.0, 0.0
         min = (m1 < m-1) ? m1 : m - 2
 
         for k=2:min+1
-            @inbounds cc = c1[k] * c2[m-k+1]
+            @inbounds cc = src_ceps[k] * dst_ceps[m-k+1]
             ss2 += (k-1) * cc
             ss1 += (m-k) * cc
         end
 
         if m <= m1+1
-            @inbounds c2[m] = c1[m] + (γ²*ss2 - γ¹*ss1)/(m-1)
+            @inbounds dst_ceps[m] = src_ceps[m] + (dst_γ*ss2 - src_γ*ss1)/(m-1)
         else
-            @inbounds c2[m] = (γ²*ss2 - γ¹*ss1)/(m-1)
+            @inbounds dst_ceps[m] = (dst_γ*ss2 - src_γ*ss1)/(m-1)
         end
     end
 
-    c2
+    dst_ceps
 end
 
-function gc2gc(c::MelGeneralizedCepstrum, m2::Int, γ²::FloatingPoint)
-    γ¹ = glog_gamma(c)
-    raw = gc2gc(rawdata(c), γ¹, m2, γ²)
-    MelGeneralizedCepstrum(allpass_alpha(c), γ², raw)
+function gc2gc(src_ceps::AbstractVector, src_γ=0.0,
+               dst_order=length(src_ceps)-1, dst_γ=0.0)
+    gc2gc!(Array(eltype(src_ceps), dst_order+1), dst_γ, src_ceps, src_γ)
+end
+
+function gc2gc{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T},
+                                          dst_order=param_order(paramdef(state)),
+                                          dst_γ=glog_gamma(paramdef(state)))
+    assert_not_ready_to_filt(state)
+
+    def = paramdef(state)
+    order = param_order(def)
+    src_α = allpass_alpha(def)
+    src_γ = glog_gamma(def)
+    data = rawdata(state)
+    normalized = (dst_γ == zero(dst_γ))
+    newdef = MelGeneralizedCepstrum(order, src_α, dst_γ)
+    SpectralParamState(newdef, gc2gc(data, src_γ, dst_order, dst_γ),
+                       has_loggain(state), normalized)
 end

--- a/src/gcep.jl
+++ b/src/gcep.jl
@@ -1,0 +1,12 @@
+function estimate(mgc::GeneralizedCepstrum, x::AbstractArray;
+                  norm=false,
+                  kargs...)
+    order = param_order(mgc)
+    γ = glog_gamma(mgc)
+    data = SPTK.gcep(x, order, γ; norm=norm, kargs...)
+    SpectralParamState(mgc, data, true, norm)
+end
+
+function gcep(x::AbstractArray, order=25, γ=0.0; kargs...)
+    estimate(MelGeneralizedCepstrum(order, 0.0, γ), x; kargs...)
+end

--- a/src/gnorm.jl
+++ b/src/gnorm.jl
@@ -1,4 +1,6 @@
-function gnorm!{T<:FloatingPoint}(c::AbstractVector{T}, γ::FloatingPoint)
+
+function gnorm!(c::AbstractVector, γ)
+    T = eltype(c)
     if γ == zero(T)
         c[1] = exp(c[1])
         return c
@@ -13,13 +15,24 @@ function gnorm!{T<:FloatingPoint}(c::AbstractVector{T}, γ::FloatingPoint)
     c
 end
 
-function gnorm{T<:FloatingPoint}(c::AbstractVector{T}, γ::FloatingPoint)
-    normalizedc = copy(c)
-    gnorm!(normalizedc, γ)
+gnorm(c::AbstractVector, γ=0.0) = gnorm!(copy(c), γ)
+
+function gnorm!{T<:GeneralizedLogCepstrum}(state::SpectralParamState{T})
+    assert_not_ready_to_filt(state)
+    assert_gain_unnormalized(state)
+
+    γ = glog_gamma(paramdef(state))
+    state.data = gnorm!(rawdata(state), γ)
+    state.gain_normalized = true
+    state
 end
 
-function gnorm(c::MelGeneralizedCepstrum)
-    γ = glog_gamma(c)
-    raw = gnorm(rawdata(c), γ)
-    MelGeneralizedCepstrum(allpass_alpha(c), γ, raw)
+function gnorm!{T<:Union{AllPoleLogCepstrum,StandardLogCepstrum}}(state::SpectralParamState{T})
+    assert_not_ready_to_filt(state)
+    assert_gain_unnormalized(state)
+    state
+end
+
+function gnorm{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    gnorm!(copy(state))
 end

--- a/src/ignorm.jl
+++ b/src/ignorm.jl
@@ -1,5 +1,5 @@
-function ignorm!{T<:FloatingPoint}(c::AbstractVector{T},
-                                   γ::FloatingPoint)
+function ignorm!(c::AbstractVector, γ)
+    T = eltype(c)
     if γ == zero(T)
         c[1] = log(c[1])
         return c
@@ -14,14 +14,24 @@ function ignorm!{T<:FloatingPoint}(c::AbstractVector{T},
     c
 end
 
-function ignorm{T<:FloatingPoint}(normalizedc::AbstractVector{T},
-                                  γ::FloatingPoint)
-    c = copy(normalizedc)
-    ignorm!(c, γ)
+ignorm(normalizedc::AbstractVector, γ=0.0) = ignorm!(copy(normalizedc), γ)
+
+function ignorm!{T<:GeneralizedLogCepstrum}(state::SpectralParamState{T})
+    assert_not_ready_to_filt(state)
+    assert_gain_normalized(state)
+
+    γ = glog_gamma(paramdef(state))
+    state.data = ignorm!(rawdata(state), γ)
+    state.gain_normalized = false
+    state
 end
 
-function ignorm(c::MelGeneralizedCepstrum)
-    γ = glog_gamma(c)
-    raw = ignorm(rawdata(c), γ)
-    MelGeneralizedCepstrum(allpass_alpha(c), γ, raw)
+function ignorm!{T<:Union{AllPoleLogCepstrum,StandardLogCepstrum}}(state::SpectralParamState{T})
+    assert_not_ready_to_filt(state)
+    assert_gain_normalized(state)
+    state
+end
+
+function ignorm{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    ignorm!(copy(state))
 end

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -1,42 +1,17 @@
 # Linear Prediction Coefficients (LPC)
 
-abstract AbstractLinearPredictionCoef{F,T,N} <: AbstractMelGeneralizedCepstrumArray{F,AllPoleLog,T,N}
-
-immutable MelLinearPredictionCoef{F<:Frequency,T<:FloatingPoint,N} <: AbstractLinearPredictionCoef{F,T,N}
-    α::T
-    γ::T
-    data::Array{T,N}
-    loggain::Bool
-
-    function MelLinearPredictionCoef(α::FloatingPoint,
-                                     data::Array{T,N},
-                                     loggain::Bool)
-        abs(α) < 1 || throw(ArgumentError("|α| < 1 is supported"))
-        @assert size(data, 1) > 1
-        new(α, -1.0, data, loggain)
+function estimate(def::LinearPredictionCoef, x::AbstractArray;
+                  use_mgcep::Bool=false, kargs...)
+    order = param_order(def)
+    data = if use_mgcep
+        _mgcep(x, order, 0.0, -1.0; otype=5, kargs...)
+    else
+        SPTK.lpc(x, order; kargs...)
     end
+    SpectralParamState(def, data, false, true)
 end
 
-function getindex(c::MelLinearPredictionCoef, i::Range, j::Real)
-    α = allpass_alpha(c)
-    MelLinearPredictionCoef(α, getindex(c.data, i, j), c.loggain)
-end
-
-typealias LinearPredictionCoef{T,N} MelLinearPredictionCoef{Linear,T,N}
-
-function MelLinearPredictionCoef{T,N}(α::T, data::Array{T,N}, loggain::Bool)
-    F = ifelse(α == zero(T), Linear, Mel)
-    MelLinearPredictionCoef{F,T,N}(α, data, loggain)
-end
-
-function MelLinearPredictionCoef(mlpc::MelLinearPredictionCoef)
-    α = allpass_alpha(mlpc)
-    MelLinearPredictionCoef(α, rawdata(mlpc), mlpc.loggain)
-end
-
-function lpc{T<:FloatingPoint,N}(x::AbstractArray{T,N},
-                                 order::Int=40,
-                                 kargs...)
-    raw = _mgcep(x, order, 0.0, -1.0; kargs..., otype=5) # force output type
-    r = MelLinearPredictionCoef{Linear,T,N}(0.0, raw, false)
+function lpc(x::AbstractArray, order=25; kargs...)
+    def = LinearPredictionCoef(order)
+    estimate(def, x; kargs...)
 end

--- a/src/lpc2lsp.jl
+++ b/src/lpc2lsp.jl
@@ -1,0 +1,10 @@
+function lpc2lsp(state::SpectralParamState{LinearPredictionCoef};
+                 loggain=false, kargs...)
+    @assert !has_loggain(state)
+    lpcdef = paramdef(state)
+    data = rawdata(state)
+    data = SPTK.lpc2lsp(data; loggain=loggain, kargs...)
+    newdef = LineSpectralPair(param_order(lpcdef))
+    SpectralParamState(newdef, data,
+                       has_loggain(state), gain_normalized(state))
+end

--- a/src/lpc2par.jl
+++ b/src/lpc2par.jl
@@ -1,0 +1,10 @@
+function lpc2par(state::SpectralParamState{LinearPredictionCoef};
+                 kargs...)
+    @assert !has_loggain(state)
+    lpcdef = paramdef(state)
+    data = rawdata(state)
+    data = SPTK.lpc2par(data; kargs...)
+    newdef = PartialAutoCorrelation(param_order(lpcdef))
+    SpectralParamState(newdef, data,
+                       has_loggain(state), gain_normalized(state))
+end

--- a/src/mc2b.jl
+++ b/src/mc2b.jl
@@ -1,4 +1,4 @@
-function mc2b!{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint)
+function mc2b!(mc::AbstractVector, α)
     b = mc
 
     for i=length(mc)-1:-1:1
@@ -7,14 +7,25 @@ function mc2b!{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint)
     b
 end
 
-function mc2b{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint)
-    b = copy(mc)
-    mc2b!(b, α)
+mc2b(mc::AbstractVector, α) = mc2b!(copy(mc), α)
+
+function mc2b!{T<:MelCepstrum}(state::SpectralParamState{T})
+    assert_not_ready_to_filt(state)
+
+    α = allpass_alpha(paramdef(state))
+    state.ready_to_filt = true
+    α == zero(α) && return state
+
+    data = rawdata(state)
+    state.data = mc2b!(data, α)
+    state
 end
 
-function mc2b{F,L,T,N}(c::MelGeneralizedCepstrum{F,L,T,N})
-    α = allpass_alpha(c)
-    γ = glog_gamma(c)
-    raw = mc2b(rawdata(c), α)
-    MelGeneralizedCepstrumFilterCoef{F,L,T,N}(α, γ, raw)
+function mc2b!{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    throw(ArgumentError("""
+                        use `mgc2b` instead of `mc2b` for mel-generalized cepstrums"""))
+end
+
+function mc2b{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T})
+    mc2b!(copy(state))
 end

--- a/src/mc2e.jl
+++ b/src/mc2e.jl
@@ -1,6 +1,5 @@
 # mc2e computes energy from mel-cepstrum.
-function mc2e{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint,
-                                len::Int)
+function mc2e(mc::AbstractVector, α=0.35, len=256)
     # back to linear frequency domain
     c = freqt(mc, len-1, -α)
 
@@ -10,12 +9,19 @@ function mc2e{T<:FloatingPoint}(mc::AbstractVector{T}, α::FloatingPoint,
     sumabs2(ir)
 end
 
-function mc2e{T<:FloatingPoint}(mc::AbstractMatrix{T}, α::FloatingPoint,
-                                len::Int)
-    [mc2e(sub(mc, 1:size(mc, 1), i), α, len) for i=1:size(mc, 2)]
+function mc2e(mc::AbstractMatrix, α=0.35, len=256)
+    r = Array{T}(size(mc, 2))
+    for i in 1:size(r, 2)
+        r[i] = mc2e(sub(mc, :, i), α, len)
+    end
+    r
 end
 
-function mc2e(c::MelGeneralizedCepstrum, len::Int)
-    α = allpass_alpha(c)
-    mc2e(rawdata(c), α, len)
+function mc2e{T<:MelCepstrum}(state::SpectralParamState{T}, len)
+    assert_not_ready_to_filt(state)
+
+    def = paramdef(state)
+    α = allpass_alpha(def)
+    data = rawdata(state)
+    mc2e(data, α, len)
 end

--- a/src/mcepalpha.jl
+++ b/src/mcepalpha.jl
@@ -3,9 +3,9 @@
 
 # mcepalpha computes appropriate α for a given sampling frequency.
 function mcepalpha(fs::Real;
-                   start::FloatingPoint=0.0,
-                   stop::FloatingPoint=1.0,
-                   step::FloatingPoint=0.001,
+                   start::Float64=0.0,
+                   stop::Float64=1.0,
+                   step::Float64=0.001,
                    numpoints::Integer=1000)
     α_candidates = start:step:stop
     mel = melscale_vector(fs, numpoints)

--- a/src/mgc2sp.jl
+++ b/src/mgc2sp.jl
@@ -1,5 +1,4 @@
-function mgc2sp(mgc::AbstractVector, α::FloatingPoint, γ::FloatingPoint,
-                fftlen::Int)
+function mgc2sp(mgc::AbstractVector, α=0.35, γ=0.0, fftlen=256)
     # transform to cesptrum
     c = mgc2mgc(mgc, α, γ, fftlen>>1, 0.0, 0.0)
 
@@ -11,8 +10,20 @@ function mgc2sp(mgc::AbstractVector, α::FloatingPoint, γ::FloatingPoint,
     rfft(buf)
 end
 
-function mgc2sp(mgc::MelGeneralizedCepstrum, fftlen::Int)
-    α = allpass_alpha(mgc)
-    γ = glog_gamma(mgc)
-    mgc2sp(rawdata(mgc), α, γ, fftlen)
+function mgc2sp{T<:AbstractFloat}(mgc::AbstractMatrix{T}, α=0.0, γ=0.0, fftlen=256)
+    sp = Array{Complex{T}}(fftlen>>1 + 1, size(mgc, 2))
+    for i in 1:size(mgc, 2)
+        @inbounds sp[:,i] = mgc2sp(sub(mgc, :, i), α, γ, fftlen)
+    end
+    sp
+end
+
+function mgc2sp{T<:MelGeneralizedCepstrum}(state::SpectralParamState{T}, fftlen=256)
+    assert_not_ready_to_filt(state)
+
+    def = paramdef(state)
+    α = allpass_alpha(def)
+    γ = glog_gamma(def)
+    data = rawdata(state)
+    mgc2sp(data, α, γ, fftlen)
 end


### PR DESCRIPTION
### New

``` julia
mcdef = MelCepstrum(order, α)
mcstate = estimate(mcdef, x)

mgcdef = MelGeneralizedCepstrum(order, α, γ)
mgcstate = estimate(mgcdef, x)
```
### Old

``` julia
mc = mcep(x, order, α)

mgc = mgcep(x, order, α, γ)
```

The new design provides a unified interface to estimate spectral parameter; `estimate(def, input)` regardless of spectral parameter definitions (e.g. MelCesptrum, GeneralizedCepstrum and MelGeneralizedCepstrum), which I think cleaner and more julian.

This PR also
- adds LPC, LSP  and PARCOR types and conversion functions
- remove un-useful codes
- more tests
- many refactors
- build on top of [SPTK.j](https://github.com/r9y9/SPTK.jl)l (which now works on Windows as well)
- requires julia v0.4-dev, especially for `call` overloading for type aliases.
